### PR TITLE
Remove counterpart and add react-intl to handle i18n

### DIFF
--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -95,19 +95,18 @@ module.exports = generators.Base.extend({
   installClientDependencies: function () {
     const newContent = {
       dependencies: {
-      'counterpart': '0.17.5',
       'flexboxgrid': '6.3.1',
       'js-cookie': '2.1.3',
       'material-ui': '0.17.3',
       'moment': '2.15.0',
       'react': '15.4.2',
       'react-dom': '15.4.2',
+      'react-intl': '2.3.0',
       'react-interpolate-component': '0.10.0',
       'react-redux': '4.4.8',
       'react-router': '2.8.1',
       'react-router-redux': '4.0.5',
       'react-tap-event-plugin': '2.0.1',
-      'react-translate-component': '0.13.1',
       'redux': '3.6.0',
       'redux-localstorage': '1.0.0-rc4',
       'redux-localstorage-filter': '0.1.1',

--- a/generators/client/templates/client/source/components/side-bar/index.jsx
+++ b/generators/client/templates/client/source/components/side-bar/index.jsx
@@ -2,7 +2,7 @@ import React, { Component, PropTypes } from 'react';
 import AppBar from 'material-ui/AppBar';
 import Drawer from 'material-ui/Drawer';
 import { List, ListItem } from 'material-ui/List';
-import Translate from 'react-translate-component';
+import { FormattedMessage } from 'react-intl';
 
 export default class SideBar extends Component {
   render() {
@@ -15,7 +15,7 @@ export default class SideBar extends Component {
         <List>
           <ListItem
             onTouchTap={this.props.onLogout}
-            primaryText={<Translate content="authentication.logout" />}
+            primaryText={<FormattedMessage id="authentication.logout" />}
           />
         </List>
       </Drawer>

--- a/generators/client/templates/client/source/containers/root/index.jsx
+++ b/generators/client/templates/client/source/containers/root/index.jsx
@@ -2,11 +2,11 @@ import React, { Component, PropTypes } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import _ from 'lodash';
-import HeaderBar from '../../components/header-bar';
-import SideBar from '../../components/side-bar';
-import { IntlProvider, addLocaleData, FormattedMessage } from 'react-intl';
+import { IntlProvider, addLocaleData } from 'react-intl';
 import fr from 'react-intl/locale-data/fr';
 import en from 'react-intl/locale-data/en';
+import HeaderBar from '../../components/header-bar';
+import SideBar from '../../components/side-bar';
 import frMessages from '../../locale/locale-fr.json';
 import enMessages from '../../locale/locale-en.json';
 
@@ -18,6 +18,8 @@ const locales = {
   fr: frMessages,
   en: enMessages,
 };
+
+addLocaleData([...fr, ...en]);
 
 export class Root extends Component {
 
@@ -55,6 +57,7 @@ export class Root extends Component {
 }
 
 Root.propTypes = {
+  languageSelected: PropTypes.string,
   authentication: PropTypes.shape({
     id: PropTypes.string,
   }),

--- a/generators/client/templates/client/source/containers/root/index.jsx
+++ b/generators/client/templates/client/source/containers/root/index.jsx
@@ -4,9 +4,20 @@ import { connect } from 'react-redux';
 import _ from 'lodash';
 import HeaderBar from '../../components/header-bar';
 import SideBar from '../../components/side-bar';
+import { IntlProvider, addLocaleData, FormattedMessage } from 'react-intl';
+import fr from 'react-intl/locale-data/fr';
+import en from 'react-intl/locale-data/en';
+import frMessages from '../../locale/locale-fr.json';
+import enMessages from '../../locale/locale-en.json';
 
 import * as AuthenticationEffect from '../../effects/authentication';
 import * as SideBarAction from '../../actions/side-bar';
+
+
+const locales = {
+  fr: frMessages,
+  en: enMessages,
+};
 
 export class Root extends Component {
 
@@ -25,17 +36,19 @@ export class Root extends Component {
   render() {
     if (_.isEmpty(this.props.authentication)) return (<div />);
     return (
-      <div>
-        <HeaderBar
-          onOpenSideBar={this.props.sideBarActions.open}
-        />
-        <SideBar
-          open={this.props.sideBar.open}
-          onCloseSideBar={this.props.sideBarActions.close}
-          onLogout={this.props.authenticationEffects.logout}
-        />
-        {this.props.children}
-      </div>
+      <IntlProvider locale={this.props.languageSelected} messages={locales[this.props.languageSelected]}>
+        <div>
+          <HeaderBar
+            onOpenSideBar={this.props.sideBarActions.open}
+          />
+          <SideBar
+            open={this.props.sideBar.open}
+            onCloseSideBar={this.props.sideBarActions.close}
+            onLogout={this.props.authenticationEffects.logout}
+          />
+          {this.props.children}
+        </div>
+      </IntlProvider>
     );
   }
 
@@ -61,6 +74,7 @@ Root.propTypes = {
 
 function mapStateToProps(state) {
   return {
+    languageSelected: state.language.selected,
     authentication: state.authentication,
     sideBar: state['side-bar'],
   };

--- a/generators/client/templates/client/source/containers/root/root.test.js
+++ b/generators/client/templates/client/source/containers/root/root.test.js
@@ -17,7 +17,7 @@ global.document = doc;
 global.window = doc.defaultView;
 
 const middleware = [thunk];
-const initialState = {};
+const initialState = { language: { selected: 'en' } };
 const mockStore = configureMockStore(middleware);
 const store = mockStore(initialState);
 
@@ -28,6 +28,7 @@ describe('<Root/>', () => {
   login.resolves({});
   const logout = sinon.spy();
   const props = {
+    languageSelected: 'en',
     sideBar: {
       open: false,
     },

--- a/generators/client/templates/client/source/locale/locale-en.json
+++ b/generators/client/templates/client/source/locale/locale-en.json
@@ -1,6 +1,4 @@
 {
   "application-name": "<%= applicationName %>",
-  "authentication": {
-    "logout": "Logout"
-  }
+  "authentication.logout": "Logout"
 }

--- a/generators/client/templates/client/source/locale/locale-fr.json
+++ b/generators/client/templates/client/source/locale/locale-fr.json
@@ -1,6 +1,4 @@
 {
   "application-name": "<%= applicationName %>",
-  "authentication": {
-    "logout": "Déconnexion"
-  }
+  "authentication.logout": "Déconnexion"
 }

--- a/generators/client/templates/client/source/main.jsx
+++ b/generators/client/templates/client/source/main.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router';
-import moment from 'moment';
 
 import lightBaseTheme from 'material-ui/styles/baseThemes/lightBaseTheme';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
@@ -9,9 +8,6 @@ import MuiThemeProvider from 'material-ui/styles/MuiThemeProvider';
 
 import 'flexboxgrid';
 import './main.css';
-
-import localeFr from './locale/locale-fr.json';
-import localeEn from './locale/locale-en.json';
 
 import routes from './routes';
 

--- a/generators/client/templates/client/source/main.jsx
+++ b/generators/client/templates/client/source/main.jsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { Router } from 'react-router';
-import counterpart from 'counterpart';
 import moment from 'moment';
 
 import lightBaseTheme from 'material-ui/styles/baseThemes/lightBaseTheme';
@@ -15,11 +14,6 @@ import localeFr from './locale/locale-fr.json';
 import localeEn from './locale/locale-en.json';
 
 import routes from './routes';
-
-moment.locale('en');
-moment.locale('fr');
-counterpart.registerTranslations('en', localeEn);
-counterpart.registerTranslations('fr', localeFr);
 
 const muiTheme = getMuiTheme(lightBaseTheme);
 

--- a/generators/client/templates/client/source/reducers/language.js
+++ b/generators/client/templates/client/source/reducers/language.js
@@ -1,13 +1,7 @@
 import _ from 'lodash';
 import moment from 'moment';
-import counterpart from 'counterpart';
 
 import types from '../constants/language';
-
-function setLocale(lang) {
-  counterpart.setLocale(lang);
-  moment.locale(lang);
-}
 
 const initialState = {
   available: [
@@ -23,8 +17,6 @@ if (global.navigator && global.navigator.language) {
     initialState.selected = key;
   }
 }
-
-setLocale(initialState.selected);
 
 export default function reducer(state = initialState, action) {
   switch (action.type) {

--- a/generators/client/templates/client/source/reducers/language.js
+++ b/generators/client/templates/client/source/reducers/language.js
@@ -1,5 +1,4 @@
 import _ from 'lodash';
-import moment from 'moment';
 
 import types from '../constants/language';
 
@@ -21,7 +20,6 @@ if (global.navigator && global.navigator.language) {
 export default function reducer(state = initialState, action) {
   switch (action.type) {
     case types.SELECT:
-      setLocale(action.lang);
       return {
         ...initialState,
         selected: action.lang,


### PR DESCRIPTION
Screenshot taken with the generated app with react-intl (see Logout which is translated): <img width="1278" alt="screen shot 2017-08-01 at 09 40 01" src="https://user-images.githubusercontent.com/5846538/28814355-8080f75a-769d-11e7-8849-330271929dba.png">
