### PR TITLE
add License link to README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,3 +109,10 @@ How to contribute?
 ==================
 
 See [CONTRIBUTING.md](CONTRIBUTING.md)
+
+License
+========
+
+License is under Apache-2.0  
+See [License](LICENSE.txt)  
+


### PR DESCRIPTION
I've added a link to Apache license through the README