### PR TITLE
Load polyfills first in webpack dev config

### DIFF
--- a/generators/client/templates/client/webpack/webpack.config.dev.js
+++ b/generators/client/templates/client/webpack/webpack.config.dev.js
@@ -12,6 +12,9 @@ module.exports = () => ({
   // Generate source maps
   devtool: 'cheap-module-source-map',
   entry: [
+    // ES6 polyfills activated first for IE
+    'babel-polyfill',
+
     // activate HMR for React
     'react-hot-loader/patch',
 
@@ -20,9 +23,6 @@ module.exports = () => ({
     // bundle the client for hot reloading
     // only- means to only hot reload for successful updates
     'webpack/hot/only-dev-server',
-
-    // ES6 polyfills
-    'babel-polyfill',
 
     // App entry point
     path.join(params.clientPath, 'source/index.dev.jsx'),


### PR DESCRIPTION
It is very useful to test a feature in your DEV environment on IE. You can now access your local app, with webpack running, on IE from a VM, local network, etc.